### PR TITLE
deploy docs fail on PR Fix

### DIFF
--- a/.github/workflows/buildDocs.yml
+++ b/.github/workflows/buildDocs.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    
+    # Grant the built-in token permission to push to the repository
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout Repository
@@ -46,9 +50,9 @@ jobs:
         run: touch docs/_build/html/.nojekyll
 
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          branch: gh-pages  # Deploy to the root of gh-pages
-          folder: docs/_build/html  # Ensure this points to the html folder
-          token: ${{ secrets.GH_PAT }}
-          clean: true  # Deletes old files before deployment
+          branch: gh-pages
+          folder: docs/_build/html
+          clean: true

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ cython_debug/
 .pypirc
 
 
+src/toolbox/_version.py


### PR DESCRIPTION
Added check to only push to gh-pages branch on merge, not PR. 
Removed PAT to use built-in GITHUB_TOKEN for auth.

It's possible this is completely wrong, so let me know if so. 